### PR TITLE
Update URL for my blog

### DIFF
--- a/config.ini.in
+++ b/config.ini.in
@@ -85,7 +85,7 @@ faceheight = 85
 [http://adam.younglogic.com/category/software/freeipa,kerberos,ldap/feed/]
 name = Adam Young
 
-[http://vda.li/en/atom.xml]
+[https://vda.li/en/freeipa.xml]
 name = Alexander Bokovoy
 
 [http://blog.benjaminlipton.com/categories/freeipa.xml]


### PR DESCRIPTION
Change to https and to freeipa-specific feed. 'http' url generates 301 (permanently moved) but planet's retriever cannot handle that.