### PR TITLE
Publish planet via github pages

### DIFF
--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -1,0 +1,31 @@
+---
+name: Build and Publish
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "0 5 * * *"
+  push:
+    branches: [master]
+
+jobs:
+  build-and-publish:
+    name: build pages
+    runs-on: ubuntu-latest
+    container:
+      image: centos/python-27-centos7
+      volumes:
+        - ${{ github.workspace }}:/opt/app-root/src
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run build script
+        run: ./planet-build-hook.sh
+
+      - name: Publish gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /opt/app-root/src/php/


### PR DESCRIPTION
Use github actions to build the planet page and publish it into `gh-pages` branch.

The idea behind this is to use [GitHub Pges](https://guides.github.com/features/pages/) as the host for FreeIPA's planet, removing the necessity of any infrastructure to build or host the pages. We can enable HTTPS as a bonus.

- I have a working version of this here: https://armandoneto.com/freeipa-planet/
- On my fork you can see the changes in action: https://github.com/netoarmando/freeipa-planet/actions