### PR TITLE
Update GitHub's checkout action

### DIFF
--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run build script
         run: ./planet-build-hook.sh


### PR DESCRIPTION
This should fix the failed 'Build and Publish' action: https://github.com/freeipa/freeipa-planet/actions.

The warning points to https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/, stating that we need to bump the node used by the mentioned action, which https://github.com/actions/checkout/issues/1047 addressed.

Bumping the version of 'actions/checkout' should fix the issue.