### PR TITLE
Use the container only to build the pages

### DIFF
--- a/.github/workflows/build-gh-pages.yml
+++ b/.github/workflows/build-gh-pages.yml
@@ -10,25 +10,26 @@ on:
 
 jobs:
   build-and-publish:
-    name: build pages
+    name: Build and publish pages
     runs-on: ubuntu-latest
-    container:
-      image: centos/python-27-centos7
-      volumes:
-        - ${{ github.workspace }}:/opt/app-root/src
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run build script
-        run: ./planet-build-hook.sh
+      - name: Build pages
+        uses: addnab/docker-run-action@v3
+        with:
+          image: centos/python-27-centos7
+          options: -v ${{ github.workspace }}:/opt/app-root/src
+          run: |
+            ./planet-build-hook.sh
 
       - name: Publish gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: /opt/app-root/src/php/
+          publish_dir: ${{ github.workspace }}/php/
           cname: planet.freeipa.org
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
Image 'centos/python-27-centos7' is old, running node version `v14.16.0`. Thus, running actions that depend on newer releases is not possible.

With `addnab/docker-run-action@v3` it's possible to execute docker only as a step.

It surely adds a new dependency, but it can be used as a temporary solution. Such as PR https://github.com/freeipa/freeipa-planet/pull/8.

This was successfully [executed on my fork](https://github.com/netoarmando/freeipa-planet/actions/runs/10510680493/job/29119883796) and published [here](https://armandoneto.com/freeipa-planet/).